### PR TITLE
init

### DIFF
--- a/src/main/kotlin/org/xodium/vanillaplus/modules/RecipeModule.kt
+++ b/src/main/kotlin/org/xodium/vanillaplus/modules/RecipeModule.kt
@@ -2,6 +2,7 @@ package org.xodium.vanillaplus.modules
 
 import org.xodium.vanillaplus.interfaces.ModuleInterface
 import org.xodium.vanillaplus.recipies.RottenFleshRecipe
+import org.xodium.vanillaplus.recipies.WoodLogRecipe
 
 /** Represents a module handling recipe mechanics within the system. */
 internal class RecipeModule : ModuleInterface<RecipeModule.Config> {
@@ -10,11 +11,13 @@ internal class RecipeModule : ModuleInterface<RecipeModule.Config> {
     init {
         if (enabled()) {
             if (config.rottenFleshToLeatherEnabled) RottenFleshRecipe.register()
+            if (config.woodToLogEnabled) WoodLogRecipe.register()
         }
     }
 
     data class Config(
         override var enabled: Boolean = true,
         var rottenFleshToLeatherEnabled: Boolean = true,
+        var woodToLogEnabled: Boolean = true,
     ) : ModuleInterface.Config
 }

--- a/src/main/kotlin/org/xodium/vanillaplus/recipies/RottenFleshRecipe.kt
+++ b/src/main/kotlin/org/xodium/vanillaplus/recipies/RottenFleshRecipe.kt
@@ -9,7 +9,7 @@ import org.bukkit.inventory.SmokingRecipe
 import org.xodium.vanillaplus.VanillaPlus.Companion.instance
 import org.xodium.vanillaplus.interfaces.RecipeInterface
 
-/** Handles the registration of wood to log conversion recipes. */
+/** Represents an object handling rotten-flesh recipe implementation within the system. */
 internal object RottenFleshRecipe : RecipeInterface {
     override fun recipes() =
         setOf(

--- a/src/main/kotlin/org/xodium/vanillaplus/recipies/WoodLogRecipe.kt
+++ b/src/main/kotlin/org/xodium/vanillaplus/recipies/WoodLogRecipe.kt
@@ -1,0 +1,48 @@
+package org.xodium.vanillaplus.recipies
+
+import org.bukkit.Material
+import org.bukkit.NamespacedKey
+import org.bukkit.inventory.ItemStack
+import org.bukkit.inventory.ShapelessRecipe
+import org.xodium.vanillaplus.VanillaPlus.Companion.instance
+import org.xodium.vanillaplus.interfaces.RecipeInterface
+
+/** Represents an object handling wood-log recipe implementation within the system. */
+internal object WoodLogRecipe : RecipeInterface {
+    private val woodToLog =
+        mapOf(
+            // Regular Logs
+            Material.OAK_WOOD to Material.OAK_LOG,
+            Material.SPRUCE_WOOD to Material.SPRUCE_LOG,
+            Material.BIRCH_WOOD to Material.BIRCH_LOG,
+            Material.JUNGLE_WOOD to Material.JUNGLE_LOG,
+            Material.ACACIA_WOOD to Material.ACACIA_LOG,
+            Material.DARK_OAK_WOOD to Material.DARK_OAK_LOG,
+            Material.MANGROVE_WOOD to Material.MANGROVE_LOG,
+            Material.CHERRY_WOOD to Material.CHERRY_LOG,
+            Material.PALE_OAK_WOOD to Material.PALE_OAK_LOG,
+            Material.CRIMSON_HYPHAE to Material.CRIMSON_STEM,
+            Material.WARPED_HYPHAE to Material.WARPED_STEM,
+            // Stripped Logs
+            Material.STRIPPED_OAK_WOOD to Material.STRIPPED_OAK_LOG,
+            Material.STRIPPED_SPRUCE_WOOD to Material.STRIPPED_SPRUCE_LOG,
+            Material.STRIPPED_BIRCH_WOOD to Material.STRIPPED_BIRCH_LOG,
+            Material.STRIPPED_JUNGLE_WOOD to Material.STRIPPED_JUNGLE_LOG,
+            Material.STRIPPED_ACACIA_WOOD to Material.STRIPPED_ACACIA_LOG,
+            Material.STRIPPED_DARK_OAK_WOOD to Material.STRIPPED_DARK_OAK_LOG,
+            Material.STRIPPED_MANGROVE_WOOD to Material.STRIPPED_MANGROVE_LOG,
+            Material.STRIPPED_CHERRY_WOOD to Material.STRIPPED_CHERRY_LOG,
+            Material.STRIPPED_PALE_OAK_WOOD to Material.STRIPPED_PALE_OAK_LOG,
+            Material.STRIPPED_CRIMSON_HYPHAE to Material.STRIPPED_CRIMSON_STEM,
+            Material.STRIPPED_WARPED_HYPHAE to Material.STRIPPED_WARPED_STEM,
+        )
+
+    override fun recipes() =
+        woodToLog
+            .map { (wood, log) ->
+                ShapelessRecipe(
+                    NamespacedKey(instance, "${wood.key.key}_to_${log.key.key}"),
+                    ItemStack.of(log),
+                ).apply { addIngredient(wood) }
+            }.toSet()
+}


### PR DESCRIPTION
This pull request introduces a new recipe that allows conversion of wood blocks to their respective log blocks, and adds configuration support for enabling or disabling this feature. The changes are grouped into recipe additions and configuration improvements.

### Recipe additions

* Added `WoodLogRecipe` object in `recipies/WoodLogRecipe.kt`, which registers shapeless recipes for converting various types of wood (including stripped and hyphae variants) into their corresponding log or stem blocks.
* Updated `RecipeModule` to import and register `WoodLogRecipe` when the new configuration flag is enabled. [[1]](diffhunk://#diff-73a5638f7921fb15f50b50a6befd9c764fd45df3628c7022f4b1bba2ddc3bef2R5) [[2]](diffhunk://#diff-73a5638f7921fb15f50b50a6befd9c764fd45df3628c7022f4b1bba2ddc3bef2R14-R21)

### Configuration improvements

* Added new `woodToLogEnabled` boolean property to `RecipeModule.Config`, allowing users to enable or disable wood-to-log conversion recipes.

### Documentation and clarity

* Improved the documentation for `RottenFleshRecipe` to clarify its purpose and distinguish it from the new wood-log recipe functionality.## Description

<!-- Summarize the change and, which issue is fixed. Include relevant motivation and context. -->

## How Has This Been Tested?

<!-- Describe tests run to verify the changes. -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] Other (please describe)

## Checklist:

- [ ] Follow style guidelines of this project.
- [ ] Perform self-review of the code.
- [ ] Comment on hard-to-understand areas.
- [ ] Update documentation accordingly.
- [ ] Ensure changes generate no new warnings.
- [ ] Add tests proving the fix is effective, or the feature works.
- [ ] Verify new and existing unit tests pass locally.
- [ ] Ensure dependent changes are merged and published.

## Additional context:

<!-- Add any other context about the PR here. -->