### PR TITLE
feat/custom-music-discs

### DIFF
--- a/src/data/SongData.kt
+++ b/src/data/SongData.kt
@@ -1,0 +1,28 @@
+package org.xodium.illyriaplus.data
+
+import io.papermc.paper.registry.data.SoundEventRegistryEntry
+import io.papermc.paper.registry.holder.RegistryHolder
+import net.kyori.adventure.text.Component
+import org.bukkit.Sound
+
+/**
+ * Holds the properties required to register a single custom jukebox song.
+ *
+ * @property soundEvent The sound event to play when this song is active in a jukebox.
+ * @property description The display name shown for this song, formatted as a text component.
+ * @property lengthInSeconds The duration of the song in seconds. Must be a positive value.
+ * @property comparatorOutput The redstone comparator output strength emitted by jukeboxes
+ *                            playing this song, in the range 0 to 15.
+ */
+@Suppress("UnstableApiUsage")
+internal data class SongData(
+    val soundEvent: RegistryHolder<Sound, SoundEventRegistryEntry>,
+    val description: Component,
+    val lengthInSeconds: Float,
+    val comparatorOutput: Int,
+) {
+    init {
+        require(lengthInSeconds > 0) { "lengthInSeconds must be positive, got $lengthInSeconds" }
+        require(comparatorOutput in 0..15) { "comparatorOutput must be in 0..15, got $comparatorOutput" }
+    }
+}

--- a/src/songs/SongInterface.kt
+++ b/src/songs/SongInterface.kt
@@ -1,0 +1,58 @@
+package org.xodium.illyriaplus.songs
+
+import io.papermc.paper.registry.RegistryAccess
+import io.papermc.paper.registry.RegistryKey
+import io.papermc.paper.registry.TypedKey
+import io.papermc.paper.registry.data.JukeboxSongRegistryEntry
+import net.kyori.adventure.key.Key
+import org.bukkit.JukeboxSong
+import org.xodium.illyriaplus.IllyriaPlus
+import org.xodium.illyriaplus.data.SongData
+
+/** Represents a collection of registerable jukebox songs within the system. */
+@Suppress("UnstableApiUsage")
+internal interface SongInterface {
+    /** The complete map of jukebox songs in this collection, keyed by registry name. */
+    val songs: Map<String, SongData>
+
+    /**
+     * The unique typed key identifying a jukebox song in the registry.
+     *
+     * @param name The registry key fragment (snake_case) of the jukebox song.
+     * @see io.papermc.paper.registry.TypedKey
+     * @see io.papermc.paper.registry.RegistryKey.JUKEBOX_SONG
+     */
+    fun key(name: String): TypedKey<JukeboxSong> =
+        TypedKey.create(RegistryKey.JUKEBOX_SONG, Key.key(IllyriaPlus.ID, name))
+
+    /**
+     * Configures the properties of a named jukebox song using the provided builder.
+     *
+     * @param name The registry key fragment (snake_case) of the jukebox song.
+     * @param builder The builder used to define the jukebox song properties.
+     * @return The builder for method chaining.
+     * @throws NoSuchElementException if the jukebox song is not found in [songs].
+     */
+    fun invoke(
+        name: String,
+        builder: JukeboxSongRegistryEntry.Builder,
+    ): JukeboxSongRegistryEntry.Builder =
+        songs.getValue(name).let { song ->
+            builder.apply {
+                soundEvent(song.soundEvent)
+                description(song.description)
+                lengthInSeconds(song.lengthInSeconds)
+                comparatorOutput(song.comparatorOutput)
+            }
+        }
+
+    /**
+     * Retrieves a jukebox song from the registry.
+     *
+     * @param name The registry key fragment (snake_case) of the jukebox song.
+     * @return The [JukeboxSong] instance corresponding to the key.
+     * @throws NoSuchElementException if the jukebox song is not found in the registry.
+     */
+    fun get(name: String): JukeboxSong =
+        RegistryAccess.registryAccess().getRegistry(RegistryKey.JUKEBOX_SONG).getOrThrow(key(name))
+}


### PR DESCRIPTION
Introduces `SongData` to encapsulate custom jukebox song properties and `SongInterface` for typed registry keys and registration helpers.

## Description

close #454 

## How Has This Been Tested?

<!-- Describe tests run to verify the changes. -->

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] Other (please describe)
